### PR TITLE
Make vest stay on the selected pattern

### DIFF
--- a/src/unisparks/button.cpp
+++ b/src/unisparks/button.cpp
@@ -123,6 +123,7 @@ void modeAct(Player& player, uint32_t currentMillis) {
       info("%u Next button has been hit", currentMillis);
       player.stopSpecial();
       player.next();
+      player.loopOne();
       break;
     case kPrevious:
       info("%u Back button has been hit", currentMillis);
@@ -422,6 +423,7 @@ void doButtons(Player& player, uint32_t currentMillis) {
       info("Next button has been hit");
       player.stopSpecial();
       player.next();
+      player.loopOne();
       break;
 
     case BTN_LONGPRESS:


### PR DESCRIPTION
On power-on the vest automatically cycles through the available patterns.
If a pattern is selected by pressing the ‘next’ button, then it advances to that pattern, but it doesn’t stay on that pattern.
It continues cycling, effectively randomly, through the available patterns.
I think that once the user has consciously chosen a pattern it should stay on that pattern.