### PR TITLE
Now that we have active power management, simplify convoluted brightness logic

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -29,7 +29,7 @@ extends = env:atom_matrix
 build_flags =
   ${env:atom_matrix.build_flags}
   '-UMAX_MILLIWATTS -DMAX_MILLIWATTS=4200'  # Reduce power limit to 4W for host-connected development boards
-  -DSTART_DIM=1
+  -DFIRST_BRIGHTNESS=0
 
 [env:atom_matrix_no_sending]
 extends = env:atom_matrix
@@ -92,7 +92,7 @@ monitor_port = /dev/cu.usbserial-????
 
 [env:esp8266_dim]
 extends = env:esp8266
-build_flags = ${env:esp8266.build_flags} '-UMAX_MILLIWATTS -DMAX_MILLIWATTS=4200' -DSTART_DIM=1
+build_flags = ${env:esp8266.build_flags} '-UMAX_MILLIWATTS -DMAX_MILLIWATTS=4200' -DFIRST_BRIGHTNESS=0
 
 [env:ds33_test_a]
 extends = env:atom_matrix_no_sending

--- a/src/unisparks/board.h
+++ b/src/unisparks/board.h
@@ -35,7 +35,7 @@
 #endif // ORANGE_VEST
 
 #if CAMP_SIGN
-#  define FIRST_BRIGHTNESS 255
+#  define FIRST_BRIGHTNESS MAX_BRIGHTNESS
 #  define MATRIX_WIDTH 30
 #  define MATRIX_HEIGHT 30
 #  define LEDNUM 900
@@ -54,7 +54,7 @@
 #endif // GUPPY
 
 #if HAMMER
-#  define FIRST_BRIGHTNESS 255
+#  define FIRST_BRIGHTNESS MAX_BRIGHTNESS
 #  define MATRIX_WIDTH 1
 #  define MATRIX_HEIGHT 20
 #  define LEDNUM 20

--- a/src/unisparks/button.cpp
+++ b/src/unisparks/button.cpp
@@ -77,7 +77,7 @@ const uint8_t brightnessList[] = { 2, 4, 8, 16, 32, 64, 128, 255 };
 #define MAX_BRIGHTNESS (NUM_BRIGHTNESSES-1)
 
 #ifndef FIRST_BRIGHTNESS
-#define FIRST_BRIGHTNESS 3
+#define FIRST_BRIGHTNESS 5
 #endif // FIRST_BRIGHTNESS
 
 uint8_t brightnessCursor = FIRST_BRIGHTNESS;

--- a/src/unisparks/button.cpp
+++ b/src/unisparks/button.cpp
@@ -76,9 +76,9 @@ const uint8_t brightnessList[] = { 2, 4, 8, 16, 32, 64, 128, 255 };
 #define NUM_BRIGHTNESSES (sizeof(brightnessList) / sizeof(brightnessList[0]))
 #define MAX_BRIGHTNESS (NUM_BRIGHTNESSES-1)
 
-#  ifndef FIRST_BRIGHTNESS
-#  define FIRST_BRIGHTNESS 3
-#  endif // FIRST_BRIGHTNESS
+#ifndef FIRST_BRIGHTNESS
+#define FIRST_BRIGHTNESS 3
+#endif // FIRST_BRIGHTNESS
 
 uint8_t brightnessCursor = FIRST_BRIGHTNESS;
 

--- a/src/unisparks/button.cpp
+++ b/src/unisparks/button.cpp
@@ -72,30 +72,15 @@ uint8_t buttonStatuses[NUMBUTTONS];
 
 static constexpr uint32_t lockDelay = 10000;
 
-uint8_t brightnessCursor = 0;
+const uint8_t brightnessList[] = { 2, 4, 8, 16, 32, 64, 128, 255 };
+#define NUM_BRIGHTNESSES (sizeof(brightnessList) / sizeof(brightnessList[0]))
+#define MAX_BRIGHTNESS (NUM_BRIGHTNESSES-1)
 
-#ifndef BRIGHTER
-#  define BRIGHTER 1
-#endif // BRIGHTER
+#  ifndef FIRST_BRIGHTNESS
+#  define FIRST_BRIGHTNESS 3
+#  endif // FIRST_BRIGHTNESS
 
-// this ordering is silly but we need the highest to be last
-// in case it blows the fuse in the USB battery pack
-#if START_DIM
-#  ifndef FIRST_BRIGHTNESS
-#  define FIRST_BRIGHTNESS 1
-#  endif // FIRST_BRIGHTNESS
-const uint8_t brightnessList[] = { FIRST_BRIGHTNESS, 64, 96, 8, 16, 128};
-#elif BRIGHTER
-#  ifndef FIRST_BRIGHTNESS
-#  define FIRST_BRIGHTNESS 64
-#  endif // FIRST_BRIGHTNESS
-const uint8_t brightnessList[] = {FIRST_BRIGHTNESS, 96, 8, 16, 32, 128};
-#else // BRIGHTER
-#  ifndef FIRST_BRIGHTNESS
-#  define FIRST_BRIGHTNESS 32
-#  endif // FIRST_BRIGHTNESS
-const uint8_t brightnessList[] = { FIRST_BRIGHTNESS, 64, 96, 8, 16, 128};
-#endif // BRIGHTER
+uint8_t brightnessCursor = FIRST_BRIGHTNESS;
 
 #if ATOM_MATRIX_SCREEN
 
@@ -131,9 +116,8 @@ void modeAct(Player& player, uint32_t currentMillis) {
       player.loopOne();
       break;
     case kBrightness:
-      info("%u Brightness button has been hit", currentMillis);
-      brightnessCursor++;
-      pushBrightness();
+      brightnessCursor = (brightnessCursor + 1 < NUM_BRIGHTNESSES) ? brightnessCursor + 1 : 0;
+      info("%u Brightness button has been hit %u", currentMillis, brightnessList[brightnessCursor]);
       break;
     case kSpecial:
       info("%u Special button has been hit", currentMillis);
@@ -432,15 +416,13 @@ void doButtons(Player& player, uint32_t currentMillis) {
   // Check the brightness adjust button
   switch (btn1) {
     case BTN_RELEASED:
-      info("Brightness button has been hit");
-      brightnessCursor++;
-      pushBrightness();
+      brightnessCursor = (brightnessCursor + 1 < NUM_BRIGHTNESSES) ? brightnessCursor + 1 : 0;
+      info("Brightness button has been hit %u", brightnessList[brightnessCursor]);
       break;
 
     case BTN_LONGPRESS: // button was held down for a while
-      info("Brightness button long press");
-      brightnessCursor = 0;
-      pushBrightness();
+      brightnessCursor = FIRST_BRIGHTNESS;
+      info("Brightness button long press %u", brightnessList[brightnessCursor]);
       break;
   }
 
@@ -473,18 +455,8 @@ void doButtons(Player& player, uint32_t currentMillis) {
 #endif // !BUTTONS_DISABLED
 }
 
-uint8_t brightnessVal = FIRST_BRIGHTNESS;
-
-void pushBrightness(void) {
-  if (brightnessCursor >= sizeof(brightnessList) / sizeof(brightnessList[0])) {
-    brightnessCursor = 0;
-  }
-  brightnessVal = brightnessList[brightnessCursor];
-  info("Brightness set to %u", brightnessVal);
-}
-
 uint8_t getBrightness() {
-  return brightnessVal;
+  return brightnessList[brightnessCursor];
 }
 
 } // namespace unisparks

--- a/src/unisparks/button.h
+++ b/src/unisparks/button.h
@@ -11,7 +11,6 @@ namespace unisparks {
 void setupButtons();
 void doButtons(Player& player, uint32_t currentMillis);
 void updateButtons(uint32_t currentMillis);
-void pushBrightness(void);
 uint8_t getBrightness();
 
 } // namespace unisparks

--- a/src/unisparks/vest.cpp
+++ b/src/unisparks/vest.cpp
@@ -33,8 +33,6 @@ void vestSetup(void) {
 
   mainVestController = &FastLED.addLeds<WS2812B, LED_PIN, GRB>(
     leds, sizeof(leds)/sizeof(*leds));
-
-  pushBrightness();
 }
 
 void vestLoop(void) {


### PR DESCRIPTION
This change gets rid of START_DIM, and instead relies on the new MAX_MILLIWATTS mechanism to actively manage the power consumption. As a result we don’t need multiple different brightnessList[] arrays for different hardware configurations, and FIRST_BRIGHTNESS now indexes the desired initial entry in the array rather than being an absolute value. This results in deleting a quite a few lines of code.