### PR TITLE
Make LEDs pulse once per second to show that software is still working

### DIFF
--- a/src/unisparks/button.cpp
+++ b/src/unisparks/button.cpp
@@ -167,8 +167,12 @@ CLEDController* atomMatrixScreenController = nullptr;
 void atomScreenDisplay(uint32_t currentMillis) {
   // M5Stack recommends not setting the atom screen brightness greater
   // than 20 to avoid melting the screen/cover over the LEDs.
-  const uint32_t b = (currentMillis >> 6) & 0xF;
-  atomMatrixScreenController->showLeds(b>=8 ? 4+b : 20-b);
+  // Extract bits 6,7,8,9 from milliseconds timer to get a value that cycles from 0 to 15 every second
+  // For t values 0..7 we subtract that from 20 to get brighness 20..13
+  // For t values 8..15 we add that to 4 to get brighness 12..19
+  // This gives is a brighness that starts at 20, dims to 12, and then brighens back to 20 every second
+  const uint32_t t = (currentMillis >> 6) & 0xF;
+  atomMatrixScreenController->showLeds(t&8 ? 4+t : 20-t);
 }
 
 void atomScreenNetwork(Player& player, uint32_t /*currentMillis*/) {

--- a/src/unisparks/button.cpp
+++ b/src/unisparks/button.cpp
@@ -164,10 +164,11 @@ static const CRGB menuIconSpecial[ATOM_SCREEN_NUM_LEDS] = {
 
 CLEDController* atomMatrixScreenController = nullptr;
 
-void atomScreenDisplay() {
+void atomScreenDisplay(uint32_t currentMillis) {
   // M5Stack recommends not setting the atom screen brightness greater
   // than 20 to avoid melting the screen/cover over the LEDs.
-  atomMatrixScreenController->showLeds(20);
+  const uint32_t b = (currentMillis >> 6) & 0xF;
+  atomMatrixScreenController->showLeds(b>=8 ? b : 16-b);
 }
 
 void atomScreenNetwork(Player& player, uint32_t /*currentMillis*/) {
@@ -349,7 +350,7 @@ void doButtons(Player& player, uint32_t currentMillis) {
   }
 
   if (buttonLockState < 4) {
-    atomScreenDisplay();
+    atomScreenDisplay(currentMillis);
     return;
   } else if (buttonLockState == 4) {
     buttonLockState = 5;
@@ -373,7 +374,7 @@ void doButtons(Player& player, uint32_t currentMillis) {
   }
 #if ATOM_MATRIX_SCREEN
   atomScreenUnlocked(player, currentMillis);
-  atomScreenDisplay();
+  atomScreenDisplay(currentMillis);
 #endif // ATOM_MATRIX_SCREEN
 #elif defined(ESP8266)
   const uint8_t btn0 = buttonStatus(0);

--- a/src/unisparks/button.cpp
+++ b/src/unisparks/button.cpp
@@ -168,7 +168,7 @@ void atomScreenDisplay(uint32_t currentMillis) {
   // M5Stack recommends not setting the atom screen brightness greater
   // than 20 to avoid melting the screen/cover over the LEDs.
   const uint32_t b = (currentMillis >> 6) & 0xF;
-  atomMatrixScreenController->showLeds(b>=8 ? b : 16-b);
+  atomMatrixScreenController->showLeds(b>=8 ? 4+b : 20-b);
 }
 
 void atomScreenNetwork(Player& player, uint32_t /*currentMillis*/) {


### PR DESCRIPTION
Added a comforting heartbeat to the ATOM Matrix controller: As long as the software is running, the display will show a reassuring pulsating glow. When the pulsating stops, that means the software has crashed.